### PR TITLE
Correct make error "wget: not an http or ftp url:"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM gliderlabs/alpine:3.1
-RUN apk-install espeak opus lame flac && \
+RUN apk-install espeak opus lame flac wget && \
     apk del libstdc++
 RUN cd /tmp && \
-    wget http://downloads.xiph.org/releases/opus/opus-tools-0.1.9.tar.gz && \
+    wget http://downloads.xiph.org/releases/opus/opus-tools-0.1.9.tar.gz --no-check-certificate && \
     tar xzf opus-tools-0.1.9.tar.gz && \
     cd opus-tools-0.1.9/ && \
     apk-install build-base flac-dev opus-dev libogg-dev && \


### PR DESCRIPTION
xiph.org redirects to https, which busybox can't download. (wget: not an http or ftp url:)
Corrected this by: Installing wget first and adding --no-check-certificate so that the file gets downloaded.